### PR TITLE
Update links to point to github

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -52,25 +52,25 @@ The remainder of this guide will walk you through the steps required to configur
 - We will assume the IP address of your Nexus Repository Manager is at http://9.108.127.66:8081 and your Maven public proxy URL is http://9.108.127.66:8081/repository/maven-public/. Do not use localhost as some Maven commands are run in a Docker container and localhost will not resolve correctly
 - Your Nexus Repository Manager is using the default credentials with user name `admin` and password `admin123`
 - You are creating a Maven project based on Appsody's java-microprofile stack
-- The complete example can be found via link:code/my-java-microprofile/stack.yaml[]
+- The complete example can be found via link:https://github.com/kabanero-io/guide-nexus-repository-integration/tree/master/code/my-java-microprofile[my-java-microprofile]
 
 
 === Steps:
 
 1. Create a new Application Stack by running `appsody stack create my-java-microprofile --copy incubator/java-microprofile` on your operating system terminal
-1. Ensure you have your settings.xml file in your Maven home directory (e.g. ~/.m2). An example settings.xml can be found via link:code/my-java-microprofile/image/project/settings.xml[]
+1. Ensure you have your settings.xml file in your Maven home directory (e.g. ~/.m2). An example settings.xml can be found via link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/settings.xml[settings.xml]
 1. Go to the generated my-java-microprofile directory
 1. For every pom.xml, the Maven proxy needs to be added as a `<repository>`. The files image/project/pom.xml, image/project/pom-dev.xml, and /image/templates/default/pom.xml need to be modified. See the following files for all the changes:
-    - link:code/my-java-microprofile/image/project/pom.xml[project's pom.xml]
-    - link:code/my-java-microprofile/image/project/pom-dev.xml[project's pom-dev.xml]
-    - link:code/my-java-microprofile/templates/default/pom.xml[template's pom.xml]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/pom.xml[project's pom.xml]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/pom-dev.xml[project's pom-dev.xml]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/templates/default/pom.xml[template's pom.xml]
 1. For any mention of `mvn` or `mvnw`, the settings.xml needs to be passed in to ensure the proper settings.xml configuration needs to be used.  Note: .appsody-init.bat and .appsody-init-sh calls from your operating system, so it references ~/.m2/settings.xml, not /.m2/settings.xml. See the following files for all the changes:
-    - link:code/my-java-microprofile/image/project/.appsody-init.bat[.appsody-init.bat]
-    - link:code/my-java-microprofile/image/project/.appsody-init.sh[.appsody-init.sh]
-    - link:code/my-java-microprofile/image/project/Dockerfile[Dockerfile]
-    - link:code/my-java-microprofile/image/project/install-dev-deps.sh[install-dev-deps.sh]
-    - link:code/my-java-microprofile/image/project/validate.sh[validate.sh]
-    - link:code/my-java-microprofile/image/Dockerfile-stack[Dockerfile-stack]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/.appsody-init.bat[.appsody-init.bat]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/.appsody-init.sh[.appsody-init.sh]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/Dockerfile[Dockerfile]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/install-dev-deps.sh[install-dev-deps.sh]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/project/validate.sh[validate.sh]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-java-microprofile/image/Dockerfile-stack[Dockerfile-stack]
         - `io.takari:maven:wrapper` is changed to `io.takari:maven:0.6.1:wrapper` due to an authentication issue with the latest wrapper (link:https://github.com/takari/maven-wrapper/issues/142[issue])
 1. Go to the root directory of your stack and run `appsody stack package`.  For the purpose of this example, the publishing is done into the local dev.local and the images are not pushed to Docker hub. To push to Docker hub, follow the link:https://appsody.dev/docs/stacks/publish[publishing instructions in the Appsody documentation]
 1. The Appsody command line will output logs. Ensure you only see your proxy being used and not the official Maven repository (https://repo1.maven.org/maven2). For example, we want to see logs like: `[Docker] [INFO] Downloading from nexus: http://9.108.127.66:8081/repository/maven-public/org/apache/maven/maven-model/3.2.3/maven-model-3.2.3.jar`
@@ -110,7 +110,7 @@ The remainder of this guide will walk you through the steps required to configur
 - We will assume the IP address of your Nexus Repository Manager is at http://9.108.127.66:8081 and your NPM public proxy URL is http://9.108.127.66:8081/repository/npm-all/. Do not use localhost as some Maven commands are run in a Docker container and localhost will not resolve correctly
 - Your Nexus Repository Manager is using the default credentials with user name `admin` and password `admin123`
 - You are creating a Maven project based on Appsody's nodejs-express stack
-- The complete example can be found via link:code/my-nodejs-express[]
+- The complete example can be found via link:https://github.com/kabanero-io/guide-nexus-repository-integration/tree/master/code/my-nodejs-express[my-nodejs-express]
 - For the NPM proxy, the logs do not show logs that it is pulling from the NPM proxy. Instead, browse the NPN proxy to ensure it is being populated
 - The sampleCredential file included in this example should not be checked into a repository. This file is just for this guide to show the format
 
@@ -118,11 +118,11 @@ The remainder of this guide will walk you through the steps required to configur
 === Steps:
 
 1. Create a new Application Stack by running `appsody stack create my-nodejs-express --copy incubator/nodejs-express` on your operating system terminal
-1. From following the NPM proxy information in the prerequisites, you should have an encrypted authentication. For the default password of `admin123`, the value is `_auth=YWRtaW46YWRtaW4xMjM=`. Create a credentials file in image/project and add the server credentials for the registry. An example of the final file can be found via link:code/my-nodejs-express/image/project/sampleCredentials[sampleCredentials]. Make sure this file does not get checked into your repository to avoid the credentials being stored inappropriately
+1. From following the NPM proxy information in the prerequisites, you should have an encrypted authentication. For the default password of `admin123`, the value is `_auth=YWRtaW46YWRtaW4xMjM=`. Create a credentials file in image/project and add the server credentials for the registry. An example of the final file can be found via link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-nodejs-express/image/project/sampleCredentials[sampleCredentials]. Make sure this file does not get checked into your repository to avoid the credentials being stored inappropriately
 1. Search for "npm audit" and remove all mentions of it. The removal is required due to this link:https://issues.sonatype.org/browse/NEXUS-16954[issue]
 1. Modify the Dockerfile-stack and Dockerfile to use .npmrc before calling any `npm install` commands
-    - link:code/my-nodejs-express/image/Dockerfile-stack[Dockerfile-stack]
-    - link:code/my-nodejs-express/image/project/Dockerfile[Dockerfile]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-nodejs-express/image/Dockerfile-stack[Dockerfile-stack]
+    - link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-nodejs-express/image/project/Dockerfile[Dockerfile]
     - For both these files, the .npmrc is removed after `npm install` is called to avoid having the credentials show up in the Docker image
 1. Go to the root directory of your stack and run `appsody stack package`.  For the purpose of this example, the publishing is done into the local dev.local and the images are not pushed to Docker hub. To push to Docker hub, follow the link:https://appsody.dev/docs/stacks/publish[publishing instructions in the Appsody documentation]
 1. Run `appsody stack add-to-repo sghung2 --release-url https://github.com/sghung/appsodystacks/releases/latest/download/` in your Appsody stack root directory. Replace the repository with your own Github repository
@@ -131,5 +131,5 @@ The remainder of this guide will walk you through the steps required to configur
 1. Add your JSON file. For example: https://github.com/sghung/appsodystacks/releases/download/0.1.1/sghung2-index.json
 1. Create a new Codewind project and you should see your repo and my-nodejs-express
 1. Choose it and a directory of your choosing to install the files into
-1. The application developer must put the .npmrc file into the root directory of the project. It should not be packaged up into the stack's template or be checked into the repository. The stack architect needs to inform the application developer that credentials are needed and securely share the credentials with the application developer. The contents of the .npmrc file will be the same as [sampleCredentials](code/my-nodejs-express/image/project/sampleCredentials)
+1. The application developer must put the .npmrc file into the root directory of the project. It should not be packaged up into the stack's template or be checked into the repository. The stack architect needs to inform the application developer that credentials are needed and securely share the credentials with the application developer. The contents of the .npmrc file will be the same as link:https://github.com/kabanero-io/guide-nexus-repository-integration/blob/master/code/my-nodejs-express/image/project/sampleCredentials[sampleCredentials]
 1. The application should go into a running state and can be used for development


### PR DESCRIPTION
After the initial checkin, the code on github is now available, so I can link all the code from the guide to github. As a result, there is proper syntax colouring and the user can browse the code themselves.